### PR TITLE
upgrade action version to fix CI error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install keink
         run: sudo make keink && cp bin/keink /usr/local/bin/keink
@@ -24,16 +24,16 @@ jobs:
         run: |
           export GOPATH=$(go env GOPATH)
           mkdir -p $GOPATH/github.com/kubeedge
-          git clone -b v1.17.0 https://github.com/kubeedge/kubeedge.git $GOPATH/github.com/kubeedge/kubeedge
+          git clone -b v1.20.0 https://github.com/kubeedge/kubeedge.git $GOPATH/github.com/kubeedge/kubeedge
 
       - name: Build kubeedge/node image
         run: |
           export GOPATH=$(go env GOPATH)
-          /usr/local/bin/keink build edge-image --kube-root=$GOPATH/github.com/kubeedge/kubeedge
+          /usr/local/bin/keink build edge-image --base-image kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245 --kube-root=$GOPATH/github.com/kubeedge/kubeedge
 
       - name: Install kubectl
         run: |
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.15/bin/linux/amd64/kubectl
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.29.5/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: keink-logs
           path: /tmp/keink/logs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   end-to-end-testing:
     name: end to end testing
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: publish keink binary to github and kubeedge/node image to dockerhub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
@@ -36,7 +36,7 @@ jobs:
             /usr/local/bin/keink
 
       - name: login to dockerhub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install keink
         run: sudo make keink && cp bin/keink /usr/local/bin/keink
@@ -22,7 +22,7 @@ jobs:
         run: |
           export GOPATH=$(go env GOPATH)
           mkdir -p $GOPATH/github.com/kubeedge
-          git clone -b v1.17.0 https://github.com/kubeedge/kubeedge.git $GOPATH/github.com/kubeedge/kubeedge
+          git clone -b v1.20.0 https://github.com/kubeedge/kubeedge.git $GOPATH/github.com/kubeedge/kubeedge
 
       - name: Build kubeedge/node image
         run: |
@@ -36,7 +36,7 @@ jobs:
             /usr/local/bin/keink
 
       - name: login to dockerhub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   end-to-end-testing:
     name: end to end testing with configure file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install keink
         run: sudo make keink && cp bin/keink /usr/local/bin/keink
@@ -25,16 +25,16 @@ jobs:
         run: |
           export GOPATH=$(go env GOPATH)
           mkdir -p $GOPATH/github.com/kubeedge
-          git clone -b v1.17.0 https://github.com/kubeedge/kubeedge.git $GOPATH/github.com/kubeedge/kubeedge
+          git clone -b v1.20.0 https://github.com/kubeedge/kubeedge.git $GOPATH/github.com/kubeedge/kubeedge
 
       - name: Build kubeedge/node image
         run: |
           export GOPATH=$(go env GOPATH)
-          /usr/local/bin/keink build edge-image --kube-root=$GOPATH/github.com/kubeedge/kubeedge
+          /usr/local/bin/keink build edge-image --base-image kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245 --kube-root=$GOPATH/github.com/kubeedge/kubeedge
 
       - name: Install kubectl
         run: |
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.15/bin/linux/amd64/kubectl
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.29.5/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: keink-logs
           path: /tmp/keink/logs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/dashboard/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Currently, CI checks will fail because the github action version is too low https://github.com/kubeedge/keink/actions/runs/13834802478/job/38707176984?pr=20, so we need to upgrade the version to v4 to keep it consistent with the main repo. 

At the same time, the kubeedge main repo has been updated to version 1.20, so the kubeedge version is also upgraded synchronously so that CI can check the latest kubeedge.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```
